### PR TITLE
Use slot index for slot modification commands

### DIFF
--- a/Bartender/DataCommands/SetSlotAsEmptyCommand.cs
+++ b/Bartender/DataCommands/SetSlotAsEmptyCommand.cs
@@ -1,40 +1,34 @@
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Bartender.DataCommands;
 
-public class SetSlotAsEmptyCommand(ProfileConfig cfg, HotbarSlot barSlot, int proId) : DataCommand
+public class SetSlotAsEmptyCommand(ProfileConfig cfg, int profileIndex, int slotIndex) : DataCommand
 {
-    private ProfileConfig config { get; set; } = cfg;
-    private HotbarSlot slot { get; set; } = barSlot;
-    private int profileID { get; set; } = proId;
-    private int slotID { get; set; }
+    private ProfileConfig Config { get; set; } = cfg;
+    private int ProfileIndex { get; set; } = profileIndex;
+    private HotbarSlot OldSlot { get; set; }
+    private int SlotIndex { get; set; } = slotIndex;
 
     public override void Execute()
     {
-        HotbarSlot[] hotbar = config.GetRow(profileID);
-        int i = hotbar.ToList().IndexOf(slot);
-        slotID = i;
+        HotbarSlot[] hotbar = Config.GetRow(ProfileIndex);
+        OldSlot = hotbar[SlotIndex];
 
-        hotbar[i] = new HotbarSlot(0, RaptureHotbarModule.HotbarSlotType.Empty, 0, "", slot.Transparent);
+        hotbar[SlotIndex] = new HotbarSlot(0, RaptureHotbarModule.HotbarSlotType.Empty, 0, "", OldSlot.Transparent);
 
-        config.SetRow(hotbar, profileID);
+        Config.SetRow(hotbar, ProfileIndex);
         Bartender.Configuration.Save();
     }
 
     public override void Undo()
     {
-        HotbarSlot[] hotbar = config.GetRow(profileID);
+        HotbarSlot[] hotbar = Config.GetRow(ProfileIndex);
 
-        hotbar[slotID] = slot;
+        hotbar[SlotIndex] = OldSlot;
 
-        config.SetRow(hotbar, profileID);
+        Config.SetRow(hotbar, ProfileIndex);
         Bartender.Configuration.Save();
     }
 
-    public override string ToString() => $"Set slot #{profileID + 1} to empty.";
+    public override string ToString() => $"Set slot #{ProfileIndex + 1} to empty.";
 }

--- a/Bartender/DataCommands/ToggleSlotTransparencyCommand.cs
+++ b/Bartender/DataCommands/ToggleSlotTransparencyCommand.cs
@@ -1,39 +1,26 @@
-using Bartender.UI;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Bartender.DataCommands;
 
-public class ToggleSlotTransparencyCommand(ProfileConfig cfg, HotbarSlot barSlot, int proId) : DataCommand
+public class ToggleSlotTransparencyCommand(ProfileConfig cfg, int profileIndex, int slotIndex) : DataCommand
 {
-    private ProfileConfig config { get; set; } = cfg;
-    private HotbarSlot slot { get; set; } = barSlot;
-    private int profileID { get; set; } = proId;
-    private int slotID { get; set; }
+    private ProfileConfig Config { get; set; } = cfg;
+    private int ProfileIndex { get; set; } = profileIndex;
+    private int SlotIndex { get; set; } = slotIndex;
 
     public override void Execute()
     {
-        HotbarSlot[] hotbar = config.GetRow(profileID);
-        slotID = hotbar.ToList().IndexOf(slot);
+        HotbarSlot[] hotbar = Config.GetRow(ProfileIndex);
 
-        hotbar[slotID].Transparent = !hotbar[slotID].Transparent;
+        hotbar[SlotIndex].Transparent = !hotbar[SlotIndex].Transparent;
 
-        config.SetRow(hotbar, profileID);
+        Config.SetRow(hotbar, ProfileIndex);
         Bartender.Configuration.Save();
     }
 
     public override void Undo()
     {
-        HotbarSlot[] hotbar = config.GetRow(profileID);
-
-        hotbar[slotID].Transparent = !hotbar[slotID].Transparent;
-
-        config.SetRow(hotbar, profileID);
-        Bartender.Configuration.Save();
+        // Toggling is trivially undoable
+        Execute();
     }
 
-    public override string ToString() => $"Toggle slot transparency on [{config.Name}#bar {profileID + 1}]";
+    public override string ToString() => $"Toggle slot transparency on [{Config.Name}#bar {ProfileIndex + 1}]";
 }

--- a/Bartender/UI/ProfileUI.cs
+++ b/Bartender/UI/ProfileUI.cs
@@ -267,11 +267,11 @@ public static class ProfileUI
                 }
                 else if (ImGui.IsItemHovered() && ImGui.IsMouseClicked(ImGuiMouseButton.Right) && (ImGui.IsKeyDown(ImGuiKey.LeftShift) || ImGui.IsKeyDown(ImGuiKey.RightShift)))
                 {
-                    ToggleSlotTransparent(hotbar, action);
+                    ToggleSlotTransparent(hotbar, j);
                 }
                 else if (ImGui.IsItemHovered() && ImGui.IsMouseClicked(ImGuiMouseButton.Right) && action.CommandType != HotbarSlotType.Empty)
                 {
-                    SetSlotAsEmpty(hotbar, action);
+                    SetSlotAsEmpty(hotbar, j);
                 }
                 if (ImGui.IsItemHovered() && action.CommandType != HotbarSlotType.Empty)
                 {
@@ -341,13 +341,13 @@ public static class ProfileUI
         Bartender.AddAndExecuteCommand(new ShiftIconCommand(SelectedProfile, slot, increment, profileId));
     }
 
-    private static void ToggleSlotTransparent(int profileId, HotbarSlot slot)
+    private static void ToggleSlotTransparent(int profileId, int slotIdx)
     {
-        Bartender.AddAndExecuteCommand(new ToggleSlotTransparencyCommand(SelectedProfile, slot, profileId));
+        Bartender.AddAndExecuteCommand(new ToggleSlotTransparencyCommand(SelectedProfile!, profileId, slotIdx));
     }
 
-    private static void SetSlotAsEmpty(int profileId, HotbarSlot slot)
+    private static void SetSlotAsEmpty(int profileId, int slotIdx)
     {
-        Bartender.AddAndExecuteCommand(new SetSlotAsEmptyCommand(SelectedProfile, slot, profileId));
+        Bartender.AddAndExecuteCommand(new SetSlotAsEmptyCommand(SelectedProfile!, profileId, slotIdx));
     }
 }


### PR DESCRIPTION
I was able to fix this by changing the commands to use hotbar index rather than comparing slots for equality. This may cause other issues down-the-line though (indices can change if something is inserted for example). A more complete fix might be to consider using invisible-to-the-user UUIDs for every bar and slot. This would require changes to a lot though, and no issues should be possible right now.

I also modified the property names to be more consistent with usual C# style.

Fixes #6 