### PR TITLE
Use GameIconLookup to allow HQ items to be rendered

### DIFF
--- a/Bartender/UI/Utils/IconManager.cs
+++ b/Bartender/UI/Utils/IconManager.cs
@@ -18,7 +18,7 @@ public sealed class IconManager : IDisposable
         /*if (!iconCache.TryGetValue(id, out var ret))
             iconCache.Add(id, ret = DalamudApi.TextureProvider.GetIcon(id) ??
                 throw new ArgumentException($"Invalid icon id {id}", nameof(id)));*/
-        return DalamudApi.TextureProvider.GetFromGameIcon(id);
+        return DalamudApi.TextureProvider.GetFromGameIcon(new GameIconLookup(id % 1000000, id >= 1000000));
     }
 
     public void Dispose()


### PR DESCRIPTION
Dalamud provides a struct that can combine the non-HQ item ID and an HQ bool to get the appropriate texture. Here I use it, and use modulus to get the original icon ID and `>=` to determine if the encoded icon ID should be rendered as HQ. This is the same technique as I've seen used in other plugins.

Fixes #8 